### PR TITLE
`jbr` path has `JAVA_HOME` instead of `jbr/bin`

### DIFF
--- a/Project/Sources/Classes/studio.4dm
+++ b/Project/Sources/Classes/studio.4dm
@@ -584,43 +584,34 @@ Function _getJava()
 		
 		If (This:C1470.macOS)
 			
-			Case of 
-					
-					//______________________________________________________
-				: (This:C1470.versionCompare(This:C1470.version; "2022")>=0)  // Electric Eel | 2022.1.1
-					
-					$javaHome:=This:C1470.exe.folder("Contents/jbr/Contents/Home")
-					
-					//______________________________________________________
-				Else 
-					
-					$javaHome:=This:C1470.exe.folder("Contents/jre/jdk/Contents/Home")
-					
-					If (Not:C34($javaHome.exists))
-						
-						$javaHome:=This:C1470.exe.folder("Contents/jre/Contents/Home")
-						
-					End if 
-					
-					//______________________________________________________
-			End case 
+			If (This:C1470.exe.folder("Contents/jbr/Contents/Home").exists)  // since Electric Eel | 2022.1.1
+				
+				$javaHome:=This:C1470.exe.folder("Contents/jbr/Contents/Home")
+				
+			Else 
+				
+				$javaHome:=This:C1470.exe.folder("Contents/jre/jdk/Contents/Home")
+				
+			End if 
+			
+			If (Not:C34($javaHome.exists))
+				
+				$javaHome:=This:C1470.exe.folder("Contents/jre/Contents/Home")
+				
+			End if 
 			
 		Else 
 			
-			Case of 
-					
-					//______________________________________________________
-				: (This:C1470.versionCompare(This:C1470.version; "2022")>=0)  // Electric Eel | 2022.1.1
-					
-					$javaHome:=This:C1470.exe.parent.parent.folder("jbr/bin")
-					
-					//______________________________________________________
-				Else 
-					
-					$javaHome:=This:C1470.exe.parent.parent.folder("jre")
-					
-					//______________________________________________________
-			End case 
+			If (This:C1470.exe.parent.parent.folder("jbr").exists)  // since Electric Eel | 2022.1.1
+				
+				$javaHome:=This:C1470.exe.parent.parent.folder("jbr")
+				
+			Else 
+				
+				$javaHome:=This:C1470.exe.parent.parent.folder("jre")
+				
+			End if 
+			
 		End if 
 		
 		If ($javaHome.exists)
@@ -633,20 +624,8 @@ Function _getJava()
 				
 			Else 
 				
-				Case of 
-						
-						//______________________________________________________
-					: (This:C1470.versionCompare(This:C1470.version; "2022")>=0)  // Electric Eel | 2022.1.1
-						
-						$javaCmd:=This:C1470.javaHome.file("java.exe")
-						
-						//______________________________________________________
-					Else 
-						
-						$javaCmd:=This:C1470.javaHome.file("bin/java.exe")
-						
-						//______________________________________________________
-				End case 
+				$javaCmd:=This:C1470.javaHome.file("bin/java.exe")
+				
 			End if 
 			
 			If ($javaCmd.exists)


### PR DESCRIPTION
and just check if folder exists, no version matching (could have issue later if getting version failed)


My test is

```4d
$avd:=cs.avd.new()
$devices:=$avd.availableDevices()
```

I receive error about a bad `JAVA_HOME` **DEFINED** but wrongly defined

I have same issue in window cmd prompt if I put the same java home... (using / or \ as path folder delimiter)
but no issue with  `.../Android Studio/jbr` as `JAVA_HOME `

So I remove `bin` and my test work now