### PR TITLE
Fix error when computing history message of launched command line is an object is used

### DIFF
--- a/Project/Sources/Classes/lep.4dm
+++ b/Project/Sources/Classes/lep.4dm
@@ -293,7 +293,7 @@ Function launch($command; $arguments : Variant) : cs:C1710.lep
 			//……………………………………………………………………
 	End case 
 	
-	$history:="% "+$command+"\n"
+	$history:="% "+String:C10(This:C1470.command)+"\n"
 	
 	LAUNCH EXTERNAL PROCESS:C811(This:C1470.command; $inputStream; $outputStream; $errorStream; $pid)
 	


### PR DESCRIPTION

voir ici https://github.com/4d/4D-Mobile-App/blob/main/Project/Sources/Classes/lep.4dm#L207
qui dit que $command peut être un objet